### PR TITLE
Adds query params to site for autofill

### DIFF
--- a/src/pages/index.svelte
+++ b/src/pages/index.svelte
@@ -111,7 +111,7 @@
     <NoticeContainer>{noticeContainerInfo.description}</NoticeContainer>
     <TextInput
       bind:value={delegateInput}
-      id="delegateInput"
+      id="delegate"
       label="Delegate Wallet"
       placeholder="Example: Your hot wallet"
     />

--- a/src/pages/index.svelte
+++ b/src/pages/index.svelte
@@ -89,7 +89,7 @@
         case 2:
           submitTransaction(
             `Delegating NFT #${tokenIdInput}`,
-            `NFT#${tokenIdInput} delegated`,
+            `NFT #${tokenIdInput} delegated`,
             delegateForToken,
             [delegateInput, contractInput, tokenIdInput, true],
           );


### PR DESCRIPTION
This allows for anyone to use the following query params to auto fill out the delegate.cash form. Useful if projects want to link users directly to their contract on our site.

* `delegate`
* `contract`
* `tokenId`